### PR TITLE
Enable the DATIM mediators to be packaged and installed

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 builds
 .vagrant
 Vagrantfile
+targets/trusty/usr/share

--- a/README.md
+++ b/README.md
@@ -4,20 +4,45 @@ OpenHIM config package - for DATIM Node
 This repo allows you to create a debian package that will automatically
 configure the openhim-core server installed by the openhim-core debian package.
 
+This package will also install the two mediators required by the DATIM project:
+the file-queue mediator which allows async operations of the ADX request and the
+DATIM mediator which orchestrates the DATIM transaction.
+
 It has been configured specifically for the DATIM project. If you would like to
 create a config package for the OpenHIM for your own project, then
 [see here](https://github.com/jembi/openhim-config-pkg).
 
-Getting started
----------------
-
-Execute `.create-deb.sh` to create the package. This script will ask you if you
-want to upload to launchpad or just create a .deb file.
+After installing the package
+----------------------------
 
 When installed, the `load-initial-data.sh` script will be placed in `/etc/openhim/`
 along with the data if you ever need to run it again.
 
+The two mediators are installed in /usr/share/ each of them have a config folder
+where you can control the config. Default config is added automatically for you,
+however, you may change these as necessary.
+
 After the package is installed the user must manually set the following:
 
 * The certificate for the 2 client must be added to the trusted list in
-  the keystore.
+  the keystore and linked to each client, also their basic auth passwords must
+  be reset from the default of 'test'.
+* Then endpoint that the DATIM mediator will forward a response to can be set via
+  mediator config in the OpenHIM-console
+* Similarly, the upstream OpenHIM Global (acting as a DHIS instance) instance can
+  be configured in the OpenHIM-console as well via mediator config.
+* The two mediators are configured to use a mediators@openhim.org user to communicate
+  with core. The password of this user should be changed in the OpenHIM-cosnole
+  and then it should be updated in each of the mediators `config.json` files.
+* The /tls folder of the openhim DATIM mediator will need to be updated with its
+  proper cert and key file and a ca file for the Global IL.
+* The CSD channel's route will need to be updated to point to the Global IL.
+
+Building the package
+--------------------
+
+To copy in the mediators edit and run `./cp-mediators-into-pkg.sh`. You will have
+to setup their config for a DATIM environment.
+
+Execute `.create-deb.sh` to create the package. This script will ask you if you
+want to upload to launchpad or just create a .deb file.

--- a/cp-mediators-into-pkg.sh
+++ b/cp-mediators-into-pkg.sh
@@ -1,0 +1,9 @@
+#!/bin/bash
+set -e
+
+SRCDIR="/home/ryan/git"
+
+mkdir -p targets/trusty/usr/share
+
+cp -r $SRCDIR/openhim-mediator-datim targets/trusty/usr/share
+cp -r $SRCDIR/openhim-mediator-file-queue targets/trusty/usr/share

--- a/targets/trusty/debian/changelog
+++ b/targets/trusty/debian/changelog
@@ -1,3 +1,9 @@
+openhim-config-datim-node (0.1.0-3~trusty) trusty; urgency=medium
+
+  * Release Debian Build 0.1.0-3.
+
+ -- Ryan Crichton <ryan@jembi.org>  Thu, 07 Jan 2016 14:17:09 +0200
+
 openhim-config-datim-node (0.1.0-2~trusty) trusty; urgency=medium
 
   * Release Debian Build 0.1.0-2.

--- a/targets/trusty/debian/install
+++ b/targets/trusty/debian/install
@@ -1,1 +1,2 @@
-/etc/openhim
+/etc/*
+/usr/share/*

--- a/targets/trusty/debian/postinst
+++ b/targets/trusty/debian/postinst
@@ -6,3 +6,11 @@ sleep 10
 
 cd /etc/openhim
 ./load-initial-data.sh data.json
+
+sudo -u openhim /bin/bash /etc/openhim/install_node_4.sh
+
+chown -R openhim:openhim /usr/share/openhim-mediator-file-queue
+chown -R openhim:openhim /usr/share/openhim-mediator-datim
+
+start openhim-mediator-file-queue
+start openhim-mediator-datim

--- a/targets/trusty/etc/init/openhim-mediator-datim.conf
+++ b/targets/trusty/etc/init/openhim-mediator-datim.conf
@@ -1,0 +1,21 @@
+# OpenHIM DATIM mediator
+
+description "OpenHIM DATIM mediator"
+
+# logs to /var/log/upstart/openhim-mediator-datim.log
+console log
+
+start on runlevel [2345]
+stop on runlevel [!2345]
+
+respawn
+
+setuid openhim
+setgid openhim
+
+script
+  export PATH=/home/openhim/.nvm/versions/node/v0.12.7/bin/:$PATH
+  export NODE_TLS_REJECT_UNAUTHORIZED=0
+  cd /usr/share/openhim-mediator-datim
+  exec bash -c "source /home/openhim/.nvm/nvm.sh && nvm use 4 && npm start"
+end script

--- a/targets/trusty/etc/init/openhim-mediator-file-queue.conf
+++ b/targets/trusty/etc/init/openhim-mediator-file-queue.conf
@@ -1,0 +1,22 @@
+# OpenHIM file-queue mediator
+
+description "OpenHIM file-queue mediator"
+
+# logs to /var/log/upstart/openhim-mediator-file-queue.log
+console log
+
+start on runlevel [2345]
+stop on runlevel [!2345]
+
+respawn
+
+setuid openhim
+setgid openhim
+
+script
+  export PATH=/home/openhim/.nvm/versions/node/v0.12.7/bin/:$PATH
+  export NODE_ENV=production
+  export NODE_TLS_REJECT_UNAUTHORIZED=0
+  cd /usr/share/openhim-mediator-file-queue
+  exec bash -c "source /home/openhim/.nvm/nvm.sh && nvm use 4 && npm start"
+end script

--- a/targets/trusty/etc/openhim/data.json
+++ b/targets/trusty/etc/openhim/data.json
@@ -1,5 +1,17 @@
 {
-  "Users": [],
+  "Users": [
+    {
+      "email": "mediators@openhim.org",
+      "firstname": "Mediators",
+      "groups": [
+        "admin"
+      ],
+      "passwordAlgorithm": "sha512",
+      "passwordHash": "551f410020a0bf1241736e410ee41cfee3ed170e7bdb473c35450dc4213186b763817e9f84914792983a9536738ebbbb361800ad324a0ddc90db5ba00d128593",
+      "passwordSalt": "6d0be3d8021303ed342a6cbce69e5b53",
+      "surname": "User"
+    }
+  ],
   "Clients": [
     {
       "certFingerprint": "C1:11:36:8B:54:F8:A2:B4:AA:5B:DD:E8:C1:32:6D:1D:CE:C8:C8:E8",
@@ -35,7 +47,7 @@
       "pollingSchedule": null,
       "tcpHost": null,
       "tcpPort": null,
-      "urlPattern": "^/export$",
+      "urlPattern": "^/export.*$",
       "rewriteUrlsConfig": [],
       "addAutoRewriteRules": true,
       "rewriteUrls": false,

--- a/targets/trusty/etc/openhim/install_node_4.sh
+++ b/targets/trusty/etc/openhim/install_node_4.sh
@@ -1,0 +1,6 @@
+#!/bin/bash
+
+echo "Installing node v4 for mediators..."
+. /home/openhim/.nvm/nvm.sh
+nvm install 4
+echo "Done."


### PR DESCRIPTION
The DATIM configuration requires more than just OpenHim config, there
are two mediators that are also required. The file-queue mediator and
the datim mediator which orchestrates the ADX transaction.
